### PR TITLE
MPL-433 remove `BASE64_GOOGLE_CREDENTIALS` and `G_PROJECT_ID` dependency

### DIFF
--- a/connector/index.js
+++ b/connector/index.js
@@ -1,5 +1,3 @@
-const base64GoogleCredentials = process.env.BASE64_GOOGLE_CREDENTIALS
-const projectId = process.env.G_PROJECT_ID
 const mpipeTraceContext = process.env.MPIPE_TRACE_CONTEXT || null
 const IN_HOST  = process.env.IN_HOST
 const IN_PORT  = process.env.IN_PORT
@@ -8,11 +6,6 @@ const TOKEN    = process.env.TOKEN
 const trace = process.env.TRACE // when `TRACE` is `off`, we will not start tracer
 
 const MPIPE_STREAM_STATUS = 'MPIPE_STREAM_STATUS'
-
-const {
-  base64ToObj
-} = require('../libs/util')
-
 
 /////////////////////////////////////////////////////////////////////////////////////
 // BEGIN: initialize trace agent
@@ -27,17 +20,8 @@ const {
 let tracer
 
 if( trace !== 'off' ) {
-  if( base64GoogleCredentials && projectId ) {
-    // In case local development
-    const credentials = base64ToObj( base64GoogleCredentials )
-    tracer = require('@google-cloud/trace-agent').start({
-      projectId,
-      credentials
-    })
-  } else {
-    // On GKE
-    tracer = require('@google-cloud/trace-agent').start({})
-  }
+  // On GKE
+  tracer = require('@google-cloud/trace-agent').start({})
 } else {
   tracer = {}
   tracer.runInRootSpan = ( params, cb ) => {

--- a/event-gateway/index.test.js
+++ b/event-gateway/index.test.js
@@ -29,11 +29,6 @@ class TestServer extends EventEmitter {
   }
 }
 
-const {
-  delay,
-  spawnProcess
-} = require('../libs/util')
-
 const subscribePort = 4002
 const subscribeHost = "host.docker.internal"
 const subscribeUrl = `http://${subscribeHost}:${subscribePort}`

--- a/libs/util.test.js
+++ b/libs/util.test.js
@@ -3,8 +3,7 @@ const {
   fetchWithReconnection,
   delay,
   base64ToObj,
-  objToBase64,
-  spawnProcess
+  objToBase64
 } = require('./util')
 
 describe('fetchWithTimeout test', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyway-m-pipe-sdk",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "SDK for m-pipe",
   "engines": {
     "node": ">=10.15.0"


### PR DESCRIPTION
When user set above environment variables, this sdk will emit trace log
into user's stackdriver trace. This will happen when user use
`voice-recognize` or `translator`. To fix this issue, I removed this
dependency since it was for local development purpose.

Also I removed unused values and functions, according to `eslint`
warning.